### PR TITLE
Fixes make and incorrect typing on Ubuntu

### DIFF
--- a/src/libvoxel/voxelImage.cpp
+++ b/src/libvoxel/voxelImage.cpp
@@ -619,7 +619,7 @@ class  voxelplugins
 template<class InpT, typename T>  //! run voxel plugins
  int vxlProcess(const InpT& ins, voxelImageT<T>& img, string nam) {  return voxelplugins<T>().process(ins,img,nam);  }
 
-template<class InpT, typename First=uint8_t, typename... Rest>
+template<class InpT, typename First, typename... Rest>
  int vxlProcess(const InpT& ins, voxelImageTBase* imgPtr, string nam)  { //! detect type and run voxel plugins
 	if(auto img = dynamic_cast<voxelImageT<First>*>(imgPtr))  
 		return vxlProcess<InpT,First>(ins,*img,nam);


### PR DESCRIPTION
Hello! I am a big fan of pnflow library, thanks for maintaining it!

Unfortunately, in the current version I've encountered an error in the file `src/libvoxel/voxelImage.cpp` on line 622.
The error looks like this:

```
error: redefinition of default argument for ‘class First’
622 | template<class InpT, typename First=uint8_t, typename... Rest>
```

Because of this error the library does not build on my Ubuntu 22.04 (GCC 13.3.0)
In this pull request I propose a fix for this error, which allows the library to build correctly.